### PR TITLE
New fps limiter mode: Accurate (sleep-yield)

### DIFF
--- a/data/d3d8.ini
+++ b/data/d3d8.ini
@@ -1,10 +1,11 @@
 [MAIN]
-FPSLimit = 0
-ForceWindowedMode = 0 // activates forced windowed mode
-Direct3D8DisableMaximizedWindowedModeShim = 0 // Used to fix fullscreen issues for d3d8 games on windows 10. Don't use with ForceWindowedMode.
+FPSLimit = 0                                   // max fps (0: unlimited/off)
+FPSLimitMode = 1                               // 1: realtime (thread-lock)  -  2: accurate (sleep-yield)
+ForceWindowedMode = 0                          // activates forced windowed mode
+Direct3D8DisableMaximizedWindowedModeShim = 0  // Used to fix fullscreen issues for d3d8 games on windows 10. Do not use with ForceWindowedMode.
 
 [FORCEWINDOWED]
-UsePrimaryMonitor = 0 // move window to primary monitor
-CenterWindow = 1 // center window on screen
-BorderlessFullscreen = 0 // borderless fullscreen windowed mode
-AlwaysOnTop = 0 // window stays always on top
+UsePrimaryMonitor = 0                          // move window to primary monitor
+CenterWindow = 1                               // center window on screen
+BorderlessFullscreen = 0                       // borderless fullscreen windowed mode
+AlwaysOnTop = 0                                // window stays always on top

--- a/source/dllmain.cpp
+++ b/source/dllmain.cpp
@@ -235,11 +235,12 @@ bool WINAPI DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
 
 			if (fFPSLimit > 0.0f)
 			{
-				mFPSLimitMode = (GetPrivateProfileInt("MAIN", "FPSLimitMode", 1, path) == 2) ? FrameLimiter::FPSLimitMode::FPS_ACCURATE : FrameLimiter::FPSLimitMode::FPS_REALTIME;
-				if (mFPSLimitMode == FrameLimiter::FPSLimitMode::FPS_ACCURATE)
+				FrameLimiter::FPSLimitMode mode = (GetPrivateProfileInt("MAIN", "FPSLimitMode", 1, path) == 2) ? FrameLimiter::FPSLimitMode::FPS_ACCURATE : FrameLimiter::FPSLimitMode::FPS_REALTIME;
+				if (mode == FrameLimiter::FPSLimitMode::FPS_ACCURATE)
 					timeBeginPeriod(1);
 
-				FrameLimiter::Init(mFPSLimitMode);
+				FrameLimiter::Init(mode);
+				mFPSLimitMode = mode;
 			}
 			else
 				mFPSLimitMode = FrameLimiter::FPSLimitMode::FPS_NONE;


### PR DESCRIPTION
* Less resource-intensive way of limiting fps
* New configuration option FPSLimitMode
  - 1: original realtime-mode (busy-wait thread-lock) [default]
  - 2: new accurate-mode (sleep-yield)

#### Technical details:

The current way of timing the fps limiter using a thread-locking busy-wait loop, albeit super-accurate, is very CPU-intensive.  

As it calls QueryPerformanceCounter and does the calculations as many times as it possibly can in the given time-window between frames, it leads to a situation where, rather counterintuitively, it uses **more** resources  
 -the lighter the game is 
 -the more powerful your CPU is  
 -the lower your target framerate is  
i.e. when the delta between the set fps limit and your cpu's ability to churn out frames is larger.

It essentially locks the CPU usage to 100% while waiting until the next frame can be served. The faster your CPU is, the more QPC calculations it does and it will use 100% of the available processing power on a single thread regardless of the CPU. It might not be as noticeable on CPU's with hyperthreading as it (in oversimplified terms) locks the core at "only" 50% instead of 100%.

Here is my (not very scientific) research, using Core Temp for profiling. Its' minimum polling interval is 100ms so it's not super-accurate and there are better tools but it serves this demonstration purpose just fine.  

The game I used for testing was THPS4.  
FPS Limit was set to 60 fps.  
My CPU has 4 cores and 4 threads (no hyperthreading).  

As you can see in the all-core "realtime" image, the cpu which is being locked to 100% is jumping from one to another, presumably because of thread context switching. CPU stays at it's maximum power level and consumes 48W , which is 25W over the baseline of 23W. Not too bad, but not great either.

The issue becomes more pronounced when locking the process affinity to a single core (and thread). C0 stays at 100% all the time and power usage jumps to a whopping **187W**.

Using the "accurate" aka sleep-yield method, CPU stays at a lower power level even when locking affinity to C0. Power usage is 32W which is much better. Using all cores, power (and CPU) usage drops even lower, hovering at 29W, which is only 6W over the baseline.

![RT_1Core](https://user-images.githubusercontent.com/13628128/158715515-d0faa953-ce4b-4fbc-9756-6bcc6be04a49.png)  &nbsp;  ![RT_Allcore](https://user-images.githubusercontent.com/13628128/158715517-99e33892-04b2-4b71-9884-a50b1f77cad6.png)  

![SLP_1Core](https://user-images.githubusercontent.com/13628128/158715519-a18738fb-94af-480a-8b49-57138fb177bf.png)  &nbsp;  ![SLP_Allcore](https://user-images.githubusercontent.com/13628128/158715521-70512288-a311-4880-9a5f-f9c33482afe4.png)

On a desktop processor with adequate cooling this might not matter so much. Where this definitely does matter though, is when gaming on laptops. First of all, more power equals more heat, and you can quickly run into a issue where the heat output cannot be dissipated and CPU throttling begins, meaning FPS limiter will make your performance *worse* at that point. Using more power also means that battery will be killed quickly when ran unplugged. This is why I actually even found about this issue, when I tried to figure out why my new-ish laptop was struggling playing an old game and fans were running at 100% all the time, and the underlying cause was the fps limiter (tests above were obviously not done on this aforementioned laptop).

**Okay, so it uses (an order of magnitude) less cpu-resources, but how about the accuracy then?**  

Well, while in theory, the realtime thread-lock is obviously more accurate, in my testing I couldn't even produce a measurable difference in accuracy. Using both methods and a 60fps limit the frametime was constantly 16.67 ms without any variance whatsoever. That would mean it seems to be extremely accurate up to 10μs (0.01ms). Beyond that, as even a single call to QueryPerformanceCounter takes ~1μs and at that level of precision there are so many variables in play that I wouldn't even know how to measure correctly. In any case the accuracy difference seems to be completely negligible.  

That being said, I cannot say with 100% certainty that it is and always will be the case so YMMV. My testing was done on the last good version of Windows, 7, with most of the crap removed resulting in an environment where not much is happening in the background. Seeing the current trend of Windows adding an ever more increasing amount of crap to the OS with each iteration, I can't possibly know if using sleep-yield will always be accurate. Frametime variances and general unpredictability of performance has been certainly growing so far in newer versions of Windows. But it will probably be accurate enough anyway.

**Why Sleep(1) instead of more?**  

1. Even when using timeBeginPeriod(1) to supposedly set timer resolution to 1 millisecond, Sleep is inherently **NOT** accurate.  

   This inaccuracy adds up so it's better to only sleep for ~1ms at a time and measure the actual time yourself with QPC to maintain accuracy even though this comes at a cost of some CPU time.  

   This is also why the last Sleep(1) happens only when there is >2ms of waiting left, otherwise the thread just yields its' time-slice using Sleep(0) for those last iterations of the loop.  

2. Sleeping larger amounts of time at once could result the CPU constantly switching between lower and higher power states.

#### Conclusion:

Using sleep-yield instead of busy-wait for timing the FPS limiter seems to be a better solution overall. It uses way less resources without a measurable penalty in accuracy. I set the original "realtime" busy-wait method as default for the sake of compatibility and not changing things for now, but it could be wise to set it as the default option.